### PR TITLE
Add sandbox config

### DIFF
--- a/sandbox.config.json
+++ b/sandbox.config.json
@@ -1,0 +1,9 @@
+{
+  "template": "node",
+  "infiniteLoopProtection": true,
+  "hardReloadOnChange": false,
+  "view": "browser",
+  "container": {
+    "port": 3000
+  }
+}


### PR DESCRIPTION
To force codesandbox to use the "correct" type of environment we need to add a sandbox.config.json with these settings.

I've confirmed that it works, so just merging it ;)